### PR TITLE
Modify generate methods to call rndi/rndl methods

### DIFF
--- a/src/main/java/com/redhat/smonkey/RndInt.java
+++ b/src/main/java/com/redhat/smonkey/RndInt.java
@@ -40,9 +40,6 @@ public class RndInt implements Generator {
         int min=Utils.asInt(data.get("min"),Integer.MIN_VALUE);
         int max=Utils.asInt(data.get("max"),Integer.MAX_VALUE);
         long x=Utils.rndi(min,max);
-        long rng=(long)max-(long)min+1l;
-        x%=rng;
-        x+=(long)min;
         return nodeFactory.numberNode(x);
     }
  }

--- a/src/main/java/com/redhat/smonkey/RndLong.java
+++ b/src/main/java/com/redhat/smonkey/RndLong.java
@@ -40,9 +40,6 @@ public class RndLong implements Generator {
         long min=Utils.asLong(data.get("min"),Long.MIN_VALUE);
         long max=Utils.asLong(data.get("max"),Long.MAX_VALUE);
         long x=Utils.rndl(min, max);
-        long rng=max-min+1l;
-        x%=rng;
-        x+=(long)min;
         return nodeFactory.numberNode(x);
     }
  }


### PR DESCRIPTION
Instead of Utils.rnd.nextLong() so that min/max boundaries passed as parameters
are reflected in the output
